### PR TITLE
Require that links clicked are defined in the app, this means that @properLinks would no longer be required

### DIFF
--- a/test-app/app/router.ts
+++ b/test-app/app/router.ts
@@ -11,5 +11,5 @@ export default class Router extends EmberRouter {
 
 Router.map(function () {
   // Add route declarations here
-  this.route('*any');
+  this.route('foo');
 });

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -5,3 +5,4 @@
 {{outlet}}
 
 <a href="/foo">here</a>
+<a href="/does-not-exist">here</a>

--- a/test-support/src/routing/visit-all.ts
+++ b/test-support/src/routing/visit-all.ts
@@ -1,8 +1,15 @@
 import { assert as debugAssert } from '@ember/debug';
-import { click, currentURL, findAll } from '@ember/test-helpers';
-import { visit } from '@ember/test-helpers';
-import { find } from '@ember/test-helpers';
+import {
+  visit,
+  find,
+  getContext,
+  click,
+  currentURL,
+  findAll,
+} from '@ember/test-helpers';
 import QUnit from 'qunit';
+import type Owner from '@ember/owner';
+import type RouterService from '@ember/routing/router-service';
 
 function findInAppLinks(): string[] {
   return (findAll('a')
@@ -25,6 +32,11 @@ export async function visitAllLinks() {
   const inAppLinks = findInAppLinks();
   const queue: (string | { changeReturnTo: string })[] = [...inAppLinks];
 
+  const ctx = getContext() as unknown as { owner: Owner };
+  const router = ctx?.owner?.lookup('service:router') as RouterService;
+
+  debugAssert(`Could not find the router service`, router);
+
   while (queue.length > 0) {
     const toVisit = queue.shift();
 
@@ -38,6 +50,16 @@ export async function visitAllLinks() {
     const key = `${currentURL()}::${toVisit}`;
 
     if (visited.has(key)) continue;
+
+    const result = router.recognize(toVisit);
+
+    if (!result) {
+      assert.ok(
+        true,
+        `${toVisit} on page ${returnTo} is not recognized by this app and will be skipped`,
+      );
+      continue;
+    }
 
     await visit(returnTo);
 


### PR DESCRIPTION
This is good to do anyway, because if a `<a>`'s href isn't defined in the app, it could cause a full page load